### PR TITLE
Enable category-filtered navigation

### DIFF
--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -954,6 +954,14 @@ class _MainCategoriesPanelState extends ConsumerState<_MainCategoriesPanel> {
                             fontSize: 15,
                           ),
                         ),
+                        onTap: () {
+                          Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) => MovementsScreen(
+                                  initialCategoryId: entry.key.id),
+                            ),
+                          );
+                        },
                       ),
                     );
                   },

--- a/lib/ui/movements/movements_screen.dart
+++ b/lib/ui/movements/movements_screen.dart
@@ -12,7 +12,9 @@ import '../widgets/app_title_widget.dart';
 import '../widgets/custom_snackbar.dart';
 
 class MovementsScreen extends ConsumerStatefulWidget {
-  const MovementsScreen({Key? key}) : super(key: key);
+  const MovementsScreen({Key? key, this.initialCategoryId}) : super(key: key);
+
+  final String? initialCategoryId;
 
   @override
   ConsumerState<MovementsScreen> createState() => _MovementsScreenState();
@@ -33,13 +35,14 @@ class _MovementsScreenState extends ConsumerState<MovementsScreen> {
   @override
   void initState() {
     super.initState();
+    _selectedCategoryId = widget.initialCategoryId;
     _searchSubject.debounceTime(const Duration(milliseconds: 300)).listen((q) {
       setState(() => _query = q);
     });
     // Reset filtri avanzati ogni volta che si entra
     WidgetsBinding.instance.addPostFrameCallback((_) {
       setState(() {
-        _selectedCategoryId = null;
+        _selectedCategoryId = widget.initialCategoryId;
         _selectedPaymentTypes = {};
         _minAmount = null;
         _maxAmount = null;


### PR DESCRIPTION
## Summary
- pass optional initialCategoryId to MovementsScreen
- allow tapping a home category to open Movements with that filter

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dce93264083268642f9f4c7dd3635