### PR TITLE
feat: edit movements from swipe

### DIFF
--- a/lib/ui/movements/movements_screen.dart
+++ b/lib/ui/movements/movements_screen.dart
@@ -4,6 +4,7 @@ import 'package:rxdart/rxdart.dart';
 import '../../providers/transactions_provider.dart';
 import '../../model/transaction.dart';
 import 'transaction_card.dart';
+import 'new_transaction_sheet.dart';
 import '../../providers/period_filter_provider.dart';
 import '../../providers/categories_provider.dart';
 import '../../providers/snapshot_provider.dart';
@@ -239,14 +240,14 @@ class _MovementsScreenState extends ConsumerState<MovementsScreen> {
                     return Dismissible(
                       key: ValueKey(transaction.id),
                       background: Container(
-                        color: Colors.red,
+                        color: Theme.of(context).colorScheme.primary,
                         alignment: Alignment.centerLeft,
                         padding: const EdgeInsets.only(left: 24),
                         child: const Row(
                           children: [
-                            Icon(Icons.delete, color: Colors.white),
+                            Icon(Icons.edit, color: Colors.white),
                             SizedBox(width: 8),
-                            Text('Elimina',
+                            Text('Modifica',
                                 style: TextStyle(
                                     color: Colors.white,
                                     fontWeight: FontWeight.bold)),
@@ -269,12 +270,28 @@ class _MovementsScreenState extends ConsumerState<MovementsScreen> {
                           ],
                         ),
                       ),
+                      confirmDismiss: (direction) async {
+                        if (direction == DismissDirection.startToEnd) {
+                          await showModalBottomSheet(
+                            context: context,
+                            isScrollControlled: true,
+                            builder: (context) => NewTransactionSheet(
+                              isIncome: transaction.amount > 0,
+                              transaction: transaction,
+                            ),
+                          );
+                          return false;
+                        }
+                        return true;
+                      },
                       onDismissed: (direction) async {
-                        await ref
-                            .read(transactionsNotifierProvider.notifier)
-                            .delete(transaction.id);
-                        CustomSnackBar.show(context,
-                            message: 'Movimento eliminato');
+                        if (direction == DismissDirection.endToStart) {
+                          await ref
+                              .read(transactionsNotifierProvider.notifier)
+                              .delete(transaction.id);
+                          CustomSnackBar.show(context,
+                              message: 'Movimento eliminato');
+                        }
                       },
                       child: TransactionCard(
                         transaction: transaction,

--- a/lib/ui/movements/new_transaction_sheet.dart
+++ b/lib/ui/movements/new_transaction_sheet.dart
@@ -11,11 +11,13 @@ import 'package:collection/collection.dart';
 
 class NewTransactionSheet extends ConsumerStatefulWidget {
   final bool isIncome;
+  final Transaction? transaction;
   final void Function()? onSaved;
 
   const NewTransactionSheet({
     super.key,
     required this.isIncome,
+    this.transaction,
     this.onSaved,
   });
 
@@ -41,6 +43,15 @@ class _NewTransactionSheetState extends ConsumerState<NewTransactionSheet>
   @override
   void initState() {
     super.initState();
+    if (widget.transaction != null) {
+      final t = widget.transaction!;
+      _selectedDate = t.date;
+      _selectedPaymentType = t.paymentType;
+      _selectedCategoryId = t.categoryId;
+      _amountController.text =
+          t.amount.abs().toStringAsFixed(2).replaceAll('.', ',');
+      _descriptionController.text = t.description;
+    }
     _animationController = AnimationController(
       duration: const Duration(milliseconds: 300),
       vsync: this,
@@ -86,16 +97,25 @@ class _NewTransactionSheetState extends ConsumerState<NewTransactionSheet>
         description = selectedCategory.name;
       }
 
-      final transaction = Transaction(
-        amount: finalAmount,
-        date: _selectedDate,
-        description: description,
-        categoryId: _selectedCategoryId ?? 'default',
-        paymentType: _selectedPaymentType,
-      );
-
-      // Aggiungi la transazione al provider
-      await ref.read(transactionsNotifierProvider.notifier).add(transaction);
+      if (widget.transaction != null) {
+        final updated = widget.transaction!.copyWith(
+          amount: finalAmount,
+          date: _selectedDate,
+          description: description,
+          paymentType: _selectedPaymentType,
+        );
+        await ref.read(transactionsNotifierProvider.notifier).update(updated);
+      } else {
+        final transaction = Transaction(
+          amount: finalAmount,
+          date: _selectedDate,
+          description: description,
+          categoryId: _selectedCategoryId ?? 'default',
+          paymentType: _selectedPaymentType,
+        );
+        // Aggiungi la transazione al provider
+        await ref.read(transactionsNotifierProvider.notifier).add(transaction);
+      }
 
       // Chiudi la sheet
       Navigator.of(context).pop();
@@ -166,13 +186,23 @@ class _NewTransactionSheetState extends ConsumerState<NewTransactionSheet>
             child: Row(
               children: [
                 Icon(
-                  widget.isIncome ? Icons.add : Icons.remove,
-                  color: widget.isIncome ? Colors.green : Colors.red,
+                  widget.transaction != null
+                      ? Icons.edit
+                      : (widget.isIncome ? Icons.add : Icons.remove),
+                  color: widget.transaction != null
+                      ? theme.colorScheme.primary
+                      : (widget.isIncome ? Colors.green : Colors.red),
                   size: 24,
                 ),
                 const SizedBox(width: 8),
                 Text(
-                  widget.isIncome ? 'Nuova Entrata' : 'Nuova Uscita',
+                  widget.transaction != null
+                      ? (widget.isIncome
+                          ? 'Modifica Entrata'
+                          : 'Modifica Uscita')
+                      : (widget.isIncome
+                          ? 'Nuova Entrata'
+                          : 'Nuova Uscita'),
                   style: theme.textTheme.headlineSmall,
                 ),
               ],
@@ -215,202 +245,272 @@ class _NewTransactionSheetState extends ConsumerState<NewTransactionSheet>
                     ),
                     const SizedBox(height: 16),
                     // Campo Categoria (meno alto)
-                    FormField<String>(
-                      validator: (value) {
-                        if (_selectedCategoryId == null) {
-                          return 'Seleziona una categoria';
-                        }
-                        return null;
-                      },
-                      builder: (state) => Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          GestureDetector(
-                            onTap: () async {
-                              FocusScope.of(context).unfocus();
-                              String search = '';
-                              final selected =
-                                  await showModalBottomSheet<Category>(
-                                context: context,
-                                isScrollControlled: true,
-                                backgroundColor: Colors.transparent,
-                                builder: (context) {
-                                  return StatefulBuilder(
-                                    builder: (context, setModalState) {
-                                      final filtered = filteredCategories
-                                          .where((cat) => cat.name
-                                              .toLowerCase()
-                                              .contains(search.toLowerCase()))
-                                          .toList();
-                                      return Container(
-                                        height:
-                                            MediaQuery.of(context).size.height *
-                                                0.95,
-                                        decoration: BoxDecoration(
-                                          color: Theme.of(context)
-                                              .colorScheme
-                                              .surface,
-                                          borderRadius:
-                                              const BorderRadius.vertical(
-                                                  top: Radius.circular(24)),
-                                        ),
-                                        padding: const EdgeInsets.all(24),
-                                        child: Column(
-                                          crossAxisAlignment:
-                                              CrossAxisAlignment.stretch,
-                                          children: [
-                                            Text('Seleziona categoria',
-                                                style: Theme.of(context)
-                                                    .textTheme
-                                                    .titleLarge),
-                                            const SizedBox(height: 12),
-                                            TextField(
-                                              decoration: const InputDecoration(
-                                                hintText: 'Cerca categoria...',
-                                                prefixIcon: Icon(Icons.search),
-                                                border: OutlineInputBorder(),
-                                              ),
-                                              onChanged: (v) => setModalState(
-                                                  () => search = v),
-                                            ),
-                                            const SizedBox(height: 16),
-                                            Expanded(
-                                              child: ListView.separated(
-                                                itemCount: filtered.length,
-                                                separatorBuilder: (_, __) =>
-                                                    const Divider(height: 1),
-                                                itemBuilder: (context, i) {
-                                                  final cat = filtered[i];
-                                                  final selected =
-                                                      _selectedCategoryId ==
-                                                          cat.id;
-                                                  return ListTile(
-                                                    leading: CircleAvatar(
-                                                      backgroundColor: Color(
-                                                          int.parse(cat.colorHex
-                                                              .replaceFirst('#',
-                                                                  '0xff'))),
-                                                      radius: 24,
-                                                      child: Icon(
-                                                        cat.icon,
-                                                        color: Colors.white,
-                                                        size: 32,
-                                                      ),
-                                                    ),
-                                                    title: Text(cat.name,
-                                                        style: const TextStyle(
-                                                            fontSize: 18)),
-                                                    tileColor: selected
-                                                        ? Color(int.parse(cat
-                                                                .colorHex
-                                                                .replaceFirst(
-                                                                    '#',
-                                                                    '0xff')))
-                                                            .withOpacity(0.15)
-                                                        : null,
-                                                    shape:
-                                                        RoundedRectangleBorder(
-                                                            borderRadius:
-                                                                BorderRadius
-                                                                    .circular(
-                                                                        12)),
-                                                    onTap: () {
-                                                      FocusScope.of(context)
-                                                          .unfocus();
-                                                      Navigator.of(context)
-                                                          .pop(cat);
-                                                    },
-                                                    trailing: selected
-                                                        ? const Icon(
-                                                            Icons.check,
-                                                            color: Colors.green)
-                                                        : null,
-                                                  );
-                                                },
-                                              ),
-                                            ),
-                                          ],
+                    widget.transaction != null
+                        ? InputDecorator(
+                            decoration: const InputDecoration(
+                              labelText: 'Categoria',
+                              border: OutlineInputBorder(),
+                            ),
+                            child: Row(
+                              children: [
+                                if (_selectedCategoryId != null) ...[
+                                  Builder(
+                                    builder: (context) {
+                                      final cat = filteredCategories
+                                          .firstWhereOrNull(
+                                              (c) => c.id == _selectedCategoryId);
+                                      if (cat == null) {
+                                        return const SizedBox.shrink();
+                                      }
+                                      return CircleAvatar(
+                                        backgroundColor: Color(int.parse(
+                                            cat.colorHex
+                                                .replaceFirst('#', '0xff'))),
+                                        radius: 20,
+                                        child: Icon(
+                                          cat.icon,
+                                          color: Colors.white,
+                                          size: 28,
                                         ),
                                       );
                                     },
-                                  );
-                                },
-                              );
-                              if (selected != null) {
-                                setState(
-                                    () => _selectedCategoryId = selected.id);
-                                WidgetsBinding.instance
-                                    .addPostFrameCallback((_) {
-                                  FocusScope.of(context)
-                                      .requestFocus(_focusNode);
-                                });
+                                  ),
+                                  const SizedBox(width: 16),
+                                  Text(
+                                    filteredCategories
+                                            .firstWhereOrNull(
+                                                (c) => c.id == _selectedCategoryId)
+                                            ?.name ??
+                                        '',
+                                    style: const TextStyle(fontSize: 18),
+                                  ),
+                                ]
+                              ],
+                            ),
+                          )
+                        : FormField<String>(
+                            validator: (value) {
+                              if (_selectedCategoryId == null) {
+                                return 'Seleziona una categoria';
                               }
+                              return null;
                             },
-                            child: Container(
-                              padding: const EdgeInsets.symmetric(
-                                  vertical: 10, horizontal: 12),
-                              decoration: BoxDecoration(
-                                border: Border.all(
-                                    color: Theme.of(context).dividerColor),
-                                borderRadius: BorderRadius.circular(8),
-                                color: Theme.of(context).colorScheme.surface,
-                              ),
-                              child: Row(
-                                children: [
-                                  if (_selectedCategoryId != null) ...[
-                                    Builder(
+                            builder: (state) => Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                GestureDetector(
+                                  onTap: () async {
+                                    FocusScope.of(context).unfocus();
+                                    String search = '';
+                                    final selected =
+                                        await showModalBottomSheet<Category>(
+                                      context: context,
+                                      isScrollControlled: true,
+                                      backgroundColor: Colors.transparent,
                                       builder: (context) {
-                                        final cat = filteredCategories
-                                            .firstWhereOrNull((c) =>
-                                                c.id == _selectedCategoryId);
-                                        if (cat == null)
-                                          return const SizedBox.shrink();
-                                        return CircleAvatar(
-                                          backgroundColor: Color(int.parse(cat
-                                              .colorHex
-                                              .replaceFirst('#', '0xff'))),
-                                          radius: 20,
-                                          child: Icon(
-                                            cat.icon,
-                                            color: Colors.white,
-                                            size: 28,
-                                          ),
+                                        return StatefulBuilder(
+                                          builder: (context, setModalState) {
+                                            final filtered = filteredCategories
+                                                .where((cat) => cat.name
+                                                    .toLowerCase()
+                                                    .contains(
+                                                        search.toLowerCase()))
+                                                .toList();
+                                            return Container(
+                                              height: MediaQuery.of(context)
+                                                      .size
+                                                      .height *
+                                                  0.95,
+                                              decoration: BoxDecoration(
+                                                color: Theme.of(context)
+                                                    .colorScheme
+                                                    .surface,
+                                                borderRadius:
+                                                    const BorderRadius.vertical(
+                                                        top: Radius.circular(
+                                                            24)),
+                                              ),
+                                              padding: const EdgeInsets.all(24),
+                                              child: Column(
+                                                crossAxisAlignment:
+                                                    CrossAxisAlignment.stretch,
+                                                children: [
+                                                  Text('Seleziona categoria',
+                                                      style: Theme.of(context)
+                                                          .textTheme
+                                                          .titleLarge),
+                                                  const SizedBox(height: 12),
+                                                  TextField(
+                                                    decoration:
+                                                        const InputDecoration(
+                                                      hintText:
+                                                          'Cerca categoria...',
+                                                      prefixIcon:
+                                                          Icon(Icons.search),
+                                                      border:
+                                                          OutlineInputBorder(),
+                                                    ),
+                                                    onChanged: (v) =>
+                                                        setModalState(
+                                                            () => search = v),
+                                                  ),
+                                                  const SizedBox(height: 16),
+                                                  Expanded(
+                                                    child: ListView.separated(
+                                                      itemCount: filtered.length,
+                                                      separatorBuilder: (_, __) =>
+                                                          const Divider(
+                                                              height: 1),
+                                                      itemBuilder: (context, i) {
+                                                        final cat = filtered[i];
+                                                        final selected =
+                                                            _selectedCategoryId ==
+                                                                cat.id;
+                                                        return ListTile(
+                                                          leading: CircleAvatar(
+                                                            backgroundColor:
+                                                                Color(int.parse(
+                                                                    cat.colorHex
+                                                                        .replaceFirst(
+                                                                            '#',
+                                                                            '0xff'))),
+                                                            radius: 24,
+                                                            child: Icon(
+                                                              cat.icon,
+                                                              color: Colors
+                                                                  .white,
+                                                              size: 32,
+                                                            ),
+                                                          ),
+                                                          title: Text(cat.name,
+                                                              style: const TextStyle(
+                                                                  fontSize: 18)),
+                                                          tileColor: selected
+                                                              ? Color(int.parse(cat
+                                                                      .colorHex
+                                                                      .replaceFirst(
+                                                                          '#',
+                                                                          '0xff')))
+                                                                  .withOpacity(
+                                                                      0.15)
+                                                              : null,
+                                                          shape:
+                                                              RoundedRectangleBorder(
+                                                                  borderRadius:
+                                                                      BorderRadius
+                                                                          .circular(
+                                                                              12)),
+                                                          onTap: () {
+                                                            FocusScope.of(
+                                                                    context)
+                                                                .unfocus();
+                                                            Navigator.of(
+                                                                    context)
+                                                                .pop(cat);
+                                                          },
+                                                          trailing: selected
+                                                              ? const Icon(
+                                                                  Icons.check,
+                                                                  color: Colors
+                                                                      .green)
+                                                              : null,
+                                                        );
+                                                      },
+                                                    ),
+                                                  ),
+                                                ],
+                                              ),
+                                            );
+                                          },
                                         );
                                       },
+                                    );
+                                    if (selected != null) {
+                                      setState(() =>
+                                          _selectedCategoryId = selected.id);
+                                      WidgetsBinding.instance
+                                          .addPostFrameCallback((_) {
+                                        FocusScope.of(context)
+                                            .requestFocus(_focusNode);
+                                      });
+                                    }
+                                  },
+                                  child: Container(
+                                    padding: const EdgeInsets.symmetric(
+                                        vertical: 10, horizontal: 12),
+                                    decoration: BoxDecoration(
+                                      border: Border.all(
+                                          color: Theme.of(context).dividerColor),
+                                      borderRadius: BorderRadius.circular(8),
+                                      color:
+                                          Theme.of(context).colorScheme.surface,
                                     ),
-                                    const SizedBox(width: 16),
-                                    Text(
-                                      filteredCategories
-                                              .firstWhereOrNull((c) =>
-                                                  c.id == _selectedCategoryId)
-                                              ?.name ??
-                                          '',
-                                      style: const TextStyle(fontSize: 18),
+                                    child: Row(
+                                      children: [
+                                        if (_selectedCategoryId != null) ...[
+                                          Builder(
+                                            builder: (context) {
+                                              final cat = filteredCategories
+                                                  .firstWhereOrNull((c) =>
+                                                      c.id ==
+                                                      _selectedCategoryId);
+                                              if (cat == null) {
+                                                return const SizedBox.shrink();
+                                              }
+                                              return CircleAvatar(
+                                                backgroundColor: Color(
+                                                    int.parse(cat.colorHex
+                                                        .replaceFirst(
+                                                            '#', '0xff'))),
+                                                radius: 20,
+                                                child: Icon(
+                                                  cat.icon,
+                                                  color: Colors.white,
+                                                  size: 28,
+                                                ),
+                                              );
+                                            },
+                                          ),
+                                          const SizedBox(width: 16),
+                                          Text(
+                                            filteredCategories
+                                                    .firstWhereOrNull(
+                                                        (c) =>
+                                                            c.id ==
+                                                            _selectedCategoryId)
+                                                    ?.name ??
+                                                '',
+                                            style:
+                                                const TextStyle(fontSize: 18),
+                                          ),
+                                        ] else
+                                          Text('Seleziona categoria',
+                                              style: TextStyle(
+                                                  color: Theme.of(context)
+                                                      .hintColor,
+                                                  fontSize: 18)),
+                                        const Spacer(),
+                                        const Icon(Icons.expand_more),
+                                      ],
                                     ),
-                                  ] else
-                                    Text('Seleziona categoria',
-                                        style: TextStyle(
-                                            color: Theme.of(context).hintColor,
-                                            fontSize: 18)),
-                                  const Spacer(),
-                                  const Icon(Icons.expand_more),
-                                ],
-                              ),
+                                  ),
+                                ),
+                                if (state.hasError)
+                                  Padding(
+                                    padding:
+                                        const EdgeInsets.only(left: 8, top: 4),
+                                    child: Text(
+                                      state.errorText!,
+                                      style: TextStyle(
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .error,
+                                          fontSize: 13),
+                                    ),
+                                  ),
+                              ],
                             ),
                           ),
-                          if (state.hasError)
-                            Padding(
-                              padding: const EdgeInsets.only(left: 8, top: 4),
-                              child: Text(
-                                state.errorText!,
-                                style: TextStyle(
-                                    color: Theme.of(context).colorScheme.error,
-                                    fontSize: 13),
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
                     const SizedBox(height: 16),
                     // Amount Field
                     TextFormField(


### PR DESCRIPTION
## Summary
- allow right swipe on movement to open edit sheet
- lock category during edit
- delete only on left swipe

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dd17a5b448326afcd27cad9da03db