### PR TITLE
feat: remember payment type by category

### DIFF
--- a/lib/ui/movements/new_transaction_sheet.dart
+++ b/lib/ui/movements/new_transaction_sheet.dart
@@ -8,6 +8,7 @@ import '../../providers/transactions_provider.dart';
 import '../../providers/categories_provider.dart';
 import '../../model/category.dart';
 import 'package:collection/collection.dart';
+import '../../providers/repository_providers.dart';
 
 class NewTransactionSheet extends ConsumerStatefulWidget {
   final bool isIncome;
@@ -426,8 +427,15 @@ class _NewTransactionSheetState extends ConsumerState<NewTransactionSheet>
                                       },
                                     );
                                     if (selected != null) {
-                                      setState(() =>
-                                          _selectedCategoryId = selected.id);
+                                      setState(
+                                          () => _selectedCategoryId = selected.id);
+                                      final payment = await ref
+                                          .read(databaseServiceProvider)
+                                          .getPaymentTypeForCategory(selected.id);
+                                      if (payment != null) {
+                                        setState(
+                                            () => _selectedPaymentType = payment);
+                                      }
                                       WidgetsBinding.instance
                                           .addPostFrameCallback((_) {
                                         FocusScope.of(context)


### PR DESCRIPTION
## Summary
- add `category_payment_types` table and migration
- store category payment preference when saving transactions and reuse it when category is chosen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688de2e538fc8326844fa757fc89115b