### PR TITLE
Remove home app bar shadow and update misc category icon

### DIFF
--- a/lib/providers/categories_provider.dart
+++ b/lib/providers/categories_provider.dart
@@ -263,7 +263,7 @@ final List<Category> _defaultCategories = [
   Category(
     id: 'expense-misc',
     name: 'Spese varie',
-    icon: Icons.more_horiz,
+    icon: Icons.category,
     colorHex: '#9E9E9E',
     type: 'expense',
   ),

--- a/lib/services/seed_data_service.dart
+++ b/lib/services/seed_data_service.dart
@@ -212,7 +212,7 @@ class SeedDataService {
       Category(
         id: 'expense-misc',
         name: 'Spese varie',
-        icon: Icons.more_horiz,
+        icon: Icons.category,
         colorHex: '#9E9E9E',
         type: 'expense',
         isSeed: true,

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -324,6 +324,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
 
     return Scaffold(
       appBar: AppBar(
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        shadowColor: Colors.transparent,
+        surfaceTintColor: Colors.transparent,
         centerTitle: false,
         title: Row(
           mainAxisAlignment: MainAxisAlignment.start,


### PR DESCRIPTION
## Summary
- remove default shadow from home app bar on scroll
- update "Spese varie" category to use a more expressive icon

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688de43990ec8326a9eafc479a2be56f